### PR TITLE
Solarized colors in Stylus stylesheet

### DIFF
--- a/stylus-colors-solarized/style.styl
+++ b/stylus-colors-solarized/style.styl
@@ -1,0 +1,43 @@
+base03 = #002b36
+base02 = #073642
+base01 = #586e75
+base00 = #657b83
+base0 = #839496
+base1 = #93a1a1
+base2 = #eee8d5
+base3 = #fdf6e3
+yellow = #b58900
+orange = #cb4b16
+red = #d30101
+magenta = #d33682
+violet = #6c71c4
+blue = #268bd2
+cyan = #2aa198
+green = #859900
+
+rebase(rebase03, rebase02, rebase01, rebase00, rebase0, rebase1, rebase2, rebase3)
+  background-color: rebase03
+  color: rebase0
+  *
+    color: rebase0
+  h1, h2, h3, h4, h5, h6
+    color: rebase1
+    border-color: rebase0
+  a, a:active, a:visited
+    color: rebase1
+
+accentize(accent)
+  a, a:active, a:visited, code.url
+    color: accent
+  h1, h2, h3, h4, h5, h6
+    color: accent
+
+html, .light
+  rebase(base3, base2, base1, base0, base00, base01, base02, base03)
+
+.dark
+  rebase(base03, base02, base01, base00, base0, base1, base2, base3)
+
+html *
+  color-profile: sRGB
+  rendering-intent: auto


### PR DESCRIPTION
This is basically a port of the SASS example in the README for Stylus (https://github.com/LearnBoost/stylus). Not sure if it deserves a place alongside some of the more hardcore themes like the terminal app color theme, vim plugin, etc. 
