### PR TITLE
Toggling dark/light retains visual selection

### DIFF
--- a/vim-colors-solarized/colors/solarized.vim
+++ b/vim-colors-solarized/colors/solarized.vim
@@ -111,7 +111,7 @@
 " command! Togbg call ToggleBackground()
 " nnoremap <F5> :call ToggleBackground()<CR>
 " inoremap <F5> <ESC>:call ToggleBackground()<CR>a
-" vnoremap <F5> <ESC>:call ToggleBackground()<CR>
+" vnoremap <F5> <ESC>:call ToggleBackground()<CR>gv
 "
 " ---------------------------------------------------------------------
 " OPTIONS


### PR DESCRIPTION
Added `gv` to the end of your suggested visual mapping. This means that if you've got some lines highlighted and you hit <F5> to toggle dark/light, Vim keeps those lines highlighted.
