### PR TITLE
Tweaked iTerm2 dark color scheme

### DIFF
--- a/iterm2-solarized-high-contrast/Solarized Dark High Contrast.itermcolors
+++ b/iterm2-solarized-high-contrast/Solarized Dark High Contrast.itermcolors
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.19370138645172119</real>
+		<key>Green Component</key>
+		<real>0.15575926005840302</real>
+		<key>Red Component</key>
+		<real>0.0</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.14145714044570923</real>
+		<key>Green Component</key>
+		<real>0.10840655118227005</real>
+		<key>Red Component</key>
+		<real>0.81926977634429932</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.51931029558181763</real>
+		<key>Green Component</key>
+		<real>0.93699550628662109</real>
+		<key>Red Component</key>
+		<real>0.31744870543479919</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.1584954559803009</real>
+		<key>Green Component</key>
+		<real>0.49430075287818909</real>
+		<key>Red Component</key>
+		<real>0.69710838794708252</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.78393226861953735</real>
+		<key>Green Component</key>
+		<real>0.55553519725799561</real>
+		<key>Red Component</key>
+		<real>0.091996639966964722</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.55838865041732788</real>
+		<key>Green Component</key>
+		<real>0.30289158225059509</real>
+		<key>Red Component</key>
+		<real>0.88624399900436401</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.62018769979476929</real>
+		<key>Green Component</key>
+		<real>0.70167088508605957</real>
+		<key>Red Component</key>
+		<real>0.0</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.86405980587005615</real>
+		<key>Green Component</key>
+		<real>0.95794391632080078</real>
+		<key>Red Component</key>
+		<real>0.98943418264389038</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.42409399151802063</real>
+		<key>Green Component</key>
+		<real>0.7455558180809021</real>
+		<key>Red Component</key>
+		<real>0.42339208722114563</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.023484811186790466</real>
+		<key>Green Component</key>
+		<real>0.46751424670219421</real>
+		<key>Red Component</key>
+		<real>0.64746475219726562</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.78231418132781982</real>
+		<key>Green Component</key>
+		<real>0.46265947818756104</real>
+		<key>Red Component</key>
+		<real>0.12754884362220764</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.43516635894775391</real>
+		<key>Green Component</key>
+		<real>0.10802463442087173</real>
+		<key>Red Component</key>
+		<real>0.77738940715789795</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.52502274513244629</real>
+		<key>Green Component</key>
+		<real>0.57082360982894897</real>
+		<key>Red Component</key>
+		<real>0.14679534733295441</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.79781103134155273</real>
+		<key>Green Component</key>
+		<real>0.89001238346099854</real>
+		<key>Red Component</key>
+		<real>0.91611063480377197</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.53505516052246094</real>
+		<key>Green Component</key>
+		<real>0.39142724871635437</real>
+		<key>Red Component</key>
+		<real>0.0</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.23225757479667664</real>
+		<key>Green Component</key>
+		<real>0.084504462778568268</real>
+		<key>Red Component</key>
+		<real>0.95941102504730225</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.15170273184776306</real>
+		<key>Green Component</key>
+		<real>0.11783610284328461</real>
+		<key>Red Component</key>
+		<real>0.0</real>
+	</dict>
+	<key>Bold Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.82687115669250488</real>
+		<key>Green Component</key>
+		<real>0.83450067043304443</real>
+		<key>Red Component</key>
+		<real>0.70913255214691162</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.0</real>
+		<key>Green Component</key>
+		<real>0.29334646463394165</real>
+		<key>Red Component</key>
+		<real>0.95475113391876221</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.19370138645172119</real>
+		<key>Green Component</key>
+		<real>0.15575926005840302</real>
+		<key>Red Component</key>
+		<real>0.0</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.7630731463432312</real>
+		<key>Green Component</key>
+		<real>0.75921261310577393</real>
+		<key>Red Component</key>
+		<real>0.61000990867614746</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.55732053518295288</real>
+		<key>Green Component</key>
+		<real>0.56244754791259766</real>
+		<key>Red Component</key>
+		<real>0.47797361016273499</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Blue Component</key>
+		<real>0.28167051076889038</real>
+		<key>Green Component</key>
+		<real>0.21576285362243652</real>
+		<key>Red Component</key>
+		<real>0.0</real>
+	</dict>
+</dict>
+</plist>


### PR DESCRIPTION
OK, here's what I changed:

1. I made the green greener. I moved the hue further towards green, but left the saturation and brightness the same. The reason for this is that in a terminal (especially in test-driven development), green often means "success" and is the opposite of red's "failure", and better than yellow's "pending" or other half-way statuses. The green that was there looked very yellow. I think this green still fits nicely with the overall color scheme, but I know very little about this stuff, so feel free to suggest an improvement there.

2. I made the bright black brighter. I turned up its brightness so that it is now a blueish-gray. This color seems to be used as a "gray that stands out" by a few different programs I run. Before, it wasn't visible at all against the background.

3. I made the selection color brighter. This was just barely visible against the background before. Now I can easily see it.

Let me know what you think.