### PR TITLE
Vim diff filetype highlighting

### DIFF
--- a/vim-colors-solarized/colors/solarized.vim
+++ b/vim-colors-solarized/colors/solarized.vim
@@ -700,6 +700,11 @@ exe "hi! vimHiLink"         .s:fmt_none    .s:fg_blue   .s:bg_none
 exe "hi! vimHiGroup"        .s:fmt_none    .s:fg_blue   .s:bg_none
 exe "hi! vimGroup"          .s:fmt_undb    .s:fg_blue   .s:bg_none
 "}}}
+" diff highlighting "{{{
+" ---------------------------------------------------------------------
+hi! link diffAdded Statement
+hi! link diffLine Identifier
+"}}}
 " html highlighting "{{{
 " ---------------------------------------------------------------------
 exe "hi! htmlTag"           .s:fmt_none .s:fg_base01 .s:bg_none


### PR DESCRIPTION
This highlights added lines in the diff filetype (_not_ vimdiff) in green.
