### PR TITLE
Set Xresources foreground color to base0

### DIFF
--- a/xresources-colors-solarized/Xresources
+++ b/xresources-colors-solarized/Xresources
@@ -37,7 +37,7 @@
 #define S_green         #859900
 
 *background:            S_base03
-*foreground:            S_base00
+*foreground:            S_base0
 *fading:                40
 *fadeColor:             S_base03
 *cursorColor:           S_base1


### PR DESCRIPTION
According to the website,

```
Thus in the case of a dark background colorscheme, the normal relationship for background and body text is base03:base0 (please note that body text is not base00).
```
