### PR TITLE
Aligned Emacs's line numbers and mode line colors to Vim's

### DIFF
--- a/emacs-colors-solarized/color-theme-solarized.el
+++ b/emacs-colors-solarized/color-theme-solarized.el
@@ -57,7 +57,7 @@ Ported to Emacs by Greg Pfeil, http://ethanschoonover.com/solarized."
        (minibuffer-prompt ((t (:foreground ,blue))))
        (mode-line
         ((t (:foreground ,base03 :background ,base1
-                         :box (:line-width 1 :color ,base1)))))
+                         :box (:line-width 1 :color ,base03)))))
        (mode-line-buffer-id ((t (:foreground ,base03))))
        (mode-line-inactive
         ((t (:foreground ,base03  :background ,base00


### PR DESCRIPTION
Before: http://cl.ly/7ELC
After: http://cl.ly/7E81 http://cl.ly/7E6P

Note: To completely match Vim's style (as in the screenshots) it's necessary to disable fringes, enable line numbers, and set the linum-format, like this:

```
;; Disable fringes
(fringe-mode 0)

;; Enable line numbers
(global-linum-mode 1)
(setq linum-format " %d ")
```
