### PR TITLE
putty: Change cursor color to base0

### DIFF
--- a/putty-colors-solarized/solarized_dark.reg
+++ b/putty-colors-solarized/solarized_dark.reg
@@ -6,7 +6,7 @@ Windows Registry Editor Version 5.00
 "Colour2"="0,43,54"
 "Colour3"="7,54,66"
 "Colour4"="0,43,54"
-"Colour5"="238,232,213"
+"Colour5"="131,148,150"
 "Colour6"="7,54,66"
 "Colour7"="0,43,56"
 "Colour8"="220,50,47"

--- a/putty-colors-solarized/solarized_dark_puttytray.txt
+++ b/putty-colors-solarized/solarized_dark_puttytray.txt
@@ -14,7 +14,7 @@ Colour9\203,75,22\
 Colour8\220,50,47\
 Colour7\0,43,56\
 Colour6\7,54,66\
-Colour5\238,232,213\
+Colour5\131,148,150\
 Colour4\0,43,54\
 Colour3\7,54,66\
 Colour2\0,43,54\


### PR DESCRIPTION
Changed the cursor color from 'base2' to 'base0' in the Solorized Dark themes
for PuTTY and PuTTY Tray.
