### PR TITLE
markdown fix for the solarized option list

### DIFF
--- a/vim-colors-solarized/README.mkd
+++ b/vim-colors-solarized/README.mkd
@@ -4,7 +4,7 @@ Description: Precision colors for machines and people
 Author: Ethan Schoonover
 Colors: light yellow
 Created:  2011 Mar 15
-Modified: 2012 Aug 2
+Modified: 2011 Apr 16
 
 ---
 


### PR DESCRIPTION
Github's markdown renderer doesn't like the table structure that lists configurable vim options. I wrapped it in a block quote so it can be read on github.
