### PR TITLE
Fix vim-colors-solarized ToggleBG when Vim runs inside xterm

### DIFF
--- a/vim-colors-solarized/autoload/togglebg.vim
+++ b/vim-colors-solarized/autoload/togglebg.vim
@@ -26,8 +26,16 @@ tmenu ToolBar.togglebg Toggle light and dark background modes
 noremap <SID>TogBG  :call <SID>TogBG()<CR>
 
 function! s:TogBG()
-    let &background = ( &background == "dark"? "light" : "dark" )
+    " when vim runs inside a terminal, 'colorscheme' reset '&background'
+    " to terminal's default & 'background' unset 'g:colors_name'
+    if !exists("g:solarized_background")
+      let g:solarized_background = &background
+    endif
+    let g:solarized_background = ( g:solarized_background == "dark"? "light" : "dark" )
     if exists("g:colors_name")
+        let l:colors_name = g:colors_name
+        let &background = g:solarized_background
+        let g:colors_name = l:colors_name
         exe "colorscheme " . g:colors_name
     endif
 endfunction


### PR DESCRIPTION
This pull request fixed the color toggling issue when Vim runs inside xterm (Bash). This issue has been reported on the altercation/vim-colors-solarized repo tracker which you should really close.
- ToggleBG breaks colors (https://github.com/altercation/vim-colors-solarized/issues/42)

It also fixed the reset of the g:colors_name var issue that has been describe here:
- VIM Toggle function error in X11 (https://github.com/altercation/solarized/issues/55)
