### PR TITLE
Vim augroup for hitrail doesn't include s: in name

### DIFF
--- a/vim-colors-solarized/colors/solarized.vim
+++ b/vim-colors-solarized/colors/solarized.vim
@@ -1003,7 +1003,7 @@ augroup SolarizedHiTrail
     autocmd!
     if g:solarized_hitrail==1
         autocmd! Syntax * call s:SolarizedHiTrail()
-        autocmd! ColorScheme * if g:colors_name == "solarized" | call s:SolarizedHiTrail() | else | augroup! s:SolarizedHiTrail | endif
+        autocmd! ColorScheme * if g:colors_name == "solarized" | call s:SolarizedHiTrail() | else | augroup! SolarizedHiTrail | endif
     endif
 augroup END
 " }}}


### PR DESCRIPTION
This caused errors when hitrail was enabled and you switched to a different colorscheme.
