### PR TITLE
Wrong keyboard settings, wrong encoding, proper term colours

### DIFF
--- a/putty-colors-solarized/solarized_dark.reg
+++ b/putty-colors-solarized/solarized_dark.reg
@@ -23,3 +23,6 @@ Windows Registry Editor Version 5.00
 "Colour19"="147,161,161"
 "Colour20"="238,232,213"
 "Colour21"="253,246,227"
+"LineCodePage"="UTF-8"
+"LinuxFunctionKeys"=dword:00000004
+"TerminalType"="xterm-256color"


### PR DESCRIPTION
Wrong keyboard settings (numpad wasn't working), wrong encoding (powerline and similar weren't displaying), and it wasn't using the proper term colours
