### PR TITLE
feat: generate solarized_light/dark.reg for all existing sessions

### DIFF
--- a/putty-colors-solarized/generate_solarized_dark.cmd
+++ b/putty-colors-solarized/generate_solarized_dark.cmd
@@ -1,0 +1,34 @@
+@ECHO OFF
+set OUTPUT=solarized_dark.reg
+
+(
+echo Windows Registry Editor Version 5.00
+echo.
+) > %OUTPUT%
+
+FOR /F "tokens=*" %%G IN ('reg.exe QUERY HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\') DO (
+echo [%%G]
+echo "Colour0"="131,148,150"
+echo "Colour1"="147,161,161"
+echo "Colour2"="0,43,54"
+echo "Colour3"="7,54,66"
+echo "Colour4"="0,43,54"
+echo "Colour5"="238,232,213"
+echo "Colour6"="7,54,66"
+echo "Colour7"="0,43,56"
+echo "Colour8"="220,50,47"
+echo "Colour9"="203,75,22"
+echo "Colour10"="133,153,0"
+echo "Colour11"="88,110,117"
+echo "Colour12"="181,137,0"
+echo "Colour13"="101,123,131"
+echo "Colour14"="38,139,210"
+echo "Colour15"="131,148,150"
+echo "Colour16"="211,54,130"
+echo "Colour17"="108,113,196"
+echo "Colour18"="42,161,152"
+echo "Colour19"="147,161,161"
+echo "Colour20"="238,232,213"
+echo "Colour21"="253,246,227"
+echo. 
+)>> %OUTPUT%

--- a/putty-colors-solarized/generate_solarized_light.cmd
+++ b/putty-colors-solarized/generate_solarized_light.cmd
@@ -1,0 +1,34 @@
+@ECHO OFF
+set OUTPUT=solarized_light.reg
+
+(
+echo Windows Registry Editor Version 5.00
+echo.
+) > %OUTPUT%
+
+FOR /F "tokens=*" %%G IN ('reg.exe QUERY HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\') DO (
+echo [%%G]
+echo "Colour0"="101,123,131"
+echo "Colour1"="88,110,117"
+echo "Colour2"="253,246,227"
+echo "Colour3"="238,232,213"
+echo "Colour4"="238,232,213"
+echo "Colour5"="101,123,131"
+echo "Colour6"="7,54,66"
+echo "Colour7"="0,43,54"
+echo "Colour8"="220,50,47"
+echo "Colour9"="203,75,22"
+echo "Colour10"="133,153,0"
+echo "Colour11"="88,110,117"
+echo "Colour12"="181,137,0"
+echo "Colour13"="101,123,131"
+echo "Colour14"="38,139,210"
+echo "Colour15"="131,148,150"
+echo "Colour16"="211,54,130"
+echo "Colour17"="108,113,196"
+echo "Colour18"="42,161,152"
+echo "Colour19"="147,161,161"
+echo "Colour20"="238,232,213"
+echo "Colour21"="253,246,227"
+echo. 
+)>> %OUTPUT%


### PR DESCRIPTION
reg files in current form are really cumbersome to use - especially with
exising connections.

Those scripts generate reg file that will solarize all existing putty
sessions.
