### PR TITLE
Solarized broke c_space_errors in vim

### DIFF
--- a/vim-colors-solarized/colors/solarized.vim
+++ b/vim-colors-solarized/colors/solarized.vim
@@ -589,7 +589,7 @@ exe "hi! Underlined"     .s:fmt_none   .s:fg_violet .s:bg_none
 exe "hi! Ignore"         .s:fmt_none   .s:fg_none   .s:bg_none
 "       *Ignore          left blank, hidden  |hl-Ignore|
 
-exe "hi! Error"          .s:fmt_bold   .s:fg_red    .s:bg_none
+exe "hi! Error"          .s:fmt_revr   .s:fg_red    .s:bg_none
 "       *Error           any erroneous construct
 
 exe "hi! Todo"           .s:fmt_bold   .s:fg_magenta.s:bg_none


### PR DESCRIPTION
The highlight group Error was changed to be bold red text. Unfortunately,
c_space_errors highlights whitespace which has no text...  so it remained
un-highlighted effectively.

Changed the group back to reverse text, which causes the background to be red,
highlighting the whitespace.