### PR TITLE
tmux: translate -bg, -fg and -attr options into -style options

### DIFF
--- a/tmux/tmuxcolors-dark.conf
+++ b/tmux/tmuxcolors-dark.conf
@@ -1,27 +1,20 @@
 #### COLOUR (Solarized dark)
 
 # default statusbar colors
-set-option -g status-bg black #base02
-set-option -g status-fg yellow #yellow
-set-option -g status-attr default
+set-option -g status-style bg=black,fg=yellow
 
 # default window title colors
-set-window-option -g window-status-fg brightblue #base0
-set-window-option -g window-status-bg default
-#set-window-option -g window-status-attr dim
+set-window-option -g window-status-style fg=brightblue,bg=default
 
 # active window title colors
-set-window-option -g window-status-current-fg brightred #orange
-set-window-option -g window-status-current-bg default
-#set-window-option -g window-status-current-attr bright
+set-window-option -g window-status-current-style fg=brightred,bg=default
 
 # pane border
-set-option -g pane-border-fg black #base02
-set-option -g pane-active-border-fg brightgreen #base01
+set-option -g pane-border-style fg=black
+set-option -g pane-active-border-style fg=brightgreen
 
 # message text
-set-option -g message-bg black #base02
-set-option -g message-fg brightred #orange
+set-option -g message-style bg=black,fg=brightred
 
 # pane number display
 set-option -g display-panes-active-colour blue #blue

--- a/tmux/tmuxcolors-light.conf
+++ b/tmux/tmuxcolors-light.conf
@@ -1,27 +1,20 @@
 #### COLOUR (Solarized light)
 
 # default statusbar colors
-set-option -g status-bg white #base2
-set-option -g status-fg yellow #yellow
-set-option -g status-attr default
+set-option -g status-style bg=white,fg=yellow
 
 # default window title colors
-set-window-option -g window-status-fg brightyellow #base00
-set-window-option -g window-status-bg default
-#set-window-option -g window-status-attr dim
+set-window-option -g window-status-style fg=brightyellow,bg=default
 
 # active window title colors
-set-window-option -g window-status-current-fg brightred #orange
-set-window-option -g window-status-current-bg default
-#set-window-option -g window-status-current-attr bright
+set-window-option -g window-status-current-style fg=brightred,bg=default
 
 # pane border
-set-option -g pane-border-fg white #base2
-set-option -g pane-active-border-fg brightcyan #base1
+set-option -g pane-border-style fg=white
+set-option -g pane-active-border-style fg=brightcyan
 
 # message text
-set-option -g message-bg white #base2
-set-option -g message-fg brightred #orange
+set-option -g message-style bg=white,fg=brightred
 
 # pane number display
 set-option -g display-panes-active-colour blue #blue


### PR DESCRIPTION
In tmux 1.9 each set of three options were combined into a single option
and in tmux 2.9 the old options were removed.

<https://github.com/tmux/tmux/wiki/FAQ#how-do-i-translate--fg--bg-and--attr-options-into--style-options>